### PR TITLE
Fix `pfd::open_file()` on macOS for single file selection

### DIFF
--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -589,6 +589,7 @@ protected:
 
             if (in_type == type::open && allow_multiselect)
             {
+                command += "\nif class of ret is alias then\nset ret to {ret}\nend if";
                 command += "\nset s to \"\"";
                 command += "\nrepeat with i in ret";
                 command += "\n  set s to s & (POSIX path of i) & \"\\n\"";


### PR DESCRIPTION
On macOS AppleScript is used to handle the file selection in the file dialogue. The generated AppleScript contained a bug which is fixed by this PR. This fixes #8.

### Situation
There are two scenarios for selecting files which are a bit different:
- **Single file selection**: When a single file is selected the AppleScript contains `choose file with prompt "..."` which returns an `alias`
- **Multi file selection**: When multiple files are selected the AppleScript contains `choose file with multiple selections allowed with prompt "..."` which returns a list of `alias`

### Bug
When the files are selected the generated AppleScript loops over them and adds them to a string. This is where the bug occurs: The returned `alias` from case one mentioned above is not iterable and therefore won't be added to the string, which is later passed back to the application.

### Fix
The fix is fairly simple: We just check, if the result of the dialogue prompt in the AppleScript is of type `alias`, and when this is the case convert the variable into a list containing the `alias`.