### PR TITLE
Silencing 2 warning C4100

### DIFF
--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -481,6 +481,8 @@ protected:
 
                 auto callback = [&](HWND hwnd, UINT uMsg, LPARAM lp, LPARAM pData) -> INT
                 {
+                    (void)lp;
+                    (void)pData;
                     switch (uMsg)
                     {
                         case BFFM_INITIALIZED:


### PR DESCRIPTION
Simple fix to remove 2 C4100 warnings "unreferenced formal parameter"