### PR TITLE
Use IFileDialog for folder selection on Windows

### DIFF
--- a/example.cpp
+++ b/example.cpp
@@ -42,9 +42,18 @@ int main()
         case pfd::button::cancel: std::cout << "User freaked out.\n"; break;
         default: break; // Should not happen
     }
+#if _WIN32
+    std::string defaultPath = "C:\\";
+#else
+    std::string defaultPath = "/tmp/";
+#endif
+
+    // Directory selection
+    auto dir = pfd::select_folder("Select any directory", defaultPath).result();
+    std::cout << "Selected dir: " << dir << "\n";
 
     // File open
-    auto f = pfd::open_file("Choose files to read", "/tmp/",
+    auto f = pfd::open_file("Choose files to read", defaultPath,
                             { "Text Files (.txt .text)", "*.txt *.text",
                               "All Files", "*" },
                             true);

--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -454,7 +454,7 @@ protected:
     std::wstring wdefault_path;
 
     // use static function to pass as BFFCALLBACK for legacy folder select
-    static int bffcallback(HWND hwnd, UINT uMsg, LPARAM lp, LPARAM pData)
+    static int __stdcall bffcallback(HWND hwnd, UINT uMsg, LPARAM lp, LPARAM pData)
     {
         auto inst = (file_dialog*) pData;
         if(!inst)


### PR DESCRIPTION
If windows is XP or lower, use legacy approach.
In legacy folder select fix not specifying that wchar_t* is provided for title and default path.

Fix C2065 and C2100 error when compiling using MSVC 14.0

Add platform specific default folder to example.cpp
