### PR TITLE
Use a better way to set new windows style

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ example.exe
 Debug
 Release
 *.vcxproj.user
+
+.idea
+cmake-build-*


### PR DESCRIPTION
This approach works on both MSVC and MinGW and doesn't use any manifest dependencies.
Add to gitignore CLion specific ignores.

I was able to use one of the suggestions from stack overflow with some minor fixes to apply new style without manifest:
[SO answer](https://stackoverflow.com/a/10444161)

But I had to add kind of a "hack" at line 209 for this to work on windows XP. Without it this code works fine on windows 7 and 10, but on windows XP message boxes do not show and close immediately. This hack is not required if other dialogs are used (they load that dll at startup) but without them hack is necessary.


Please don't remove lines from gitignore. It's quite hard to work when you have hundreds of files from IDE in stage area.