### PR TITLE
Use checked string copy for notification on windows

### DIFF
--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -28,6 +28,7 @@
 #include <commdlg.h>
 #include <shlobj.h>
 #include <shellapi.h>
+#include <strsafe.h>
 #include <future>
 #else
 #include <cstdlib>  // for std::getenv()
@@ -994,9 +995,8 @@ public:
 
         nid->uTimeout = 5000;
 
-        // FIXME check buffer length
-        lstrcpyW(nid->szInfoTitle, internal::str2wstr(title).c_str());
-        lstrcpyW(nid->szInfo, internal::str2wstr(message).c_str());
+        StringCchCopyW(nid->szInfoTitle, ARRAYSIZE(nid->szInfoTitle), internal::str2wstr(title).c_str());
+        StringCchCopyW(nid->szInfo, ARRAYSIZE(nid->szInfo), internal::str2wstr(message).c_str());
 
         // Display the new icon
         Shell_NotifyIconW(NIM_ADD, nid.get());


### PR DESCRIPTION
If user provides very long text it will be truncated to size of bufer-1 and null-terminated:
https://docs.microsoft.com/windows/win32/api/strsafe/nf-strsafe-stringcchcopyw