### PR TITLE
Fix argument names

### DIFF
--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -500,9 +500,9 @@ protected:
 #endif
     }
 
-    std::string buttons_to_name(choice choice) const
+    std::string buttons_to_name(choice _choice) const
     {
-        switch (choice)
+        switch (_choice)
         {
             case choice::ok_cancel: return "okcancel";
             case choice::yes_no: return "yesno";
@@ -513,9 +513,9 @@ protected:
         }
     }
 
-    std::string get_icon_name(icon icon) const
+    std::string get_icon_name(icon _icon) const
     {
-        switch (icon)
+        switch (_icon)
         {
             case icon::warning: return "warning";
             case icon::error: return "error";
@@ -959,10 +959,10 @@ class notify : public internal::dialog
 public:
     notify(std::string const &title,
            std::string const &message,
-           icon icon = icon::info)
+           icon _icon = icon::info)
     {
-        if (icon == icon::question) // Not supported by notifications
-            icon = icon::info;
+        if (_icon == icon::question) // Not supported by notifications
+            _icon = icon::info;
 
 #if _WIN32
         // Use a static shared pointer for notify_icon so that we can delete
@@ -1002,7 +1002,7 @@ public:
         // - NIIF_WARNING   A warning icon.
         // - NIIF_ICON_MASK Version 6.0. Reserved.
         // - NIIF_NOSOUND   Version 6.0. Do not play the associated sound. Applies only to balloon ToolTips
-        switch (icon)
+        switch (_icon)
         {
             case icon::warning: nid->dwInfoFlags = NIIF_WARNING; break;
             case icon::error: nid->dwInfoFlags = NIIF_ERROR; break;
@@ -1036,12 +1036,12 @@ public:
         else if (is_zenity())
         {
             command += " --notification"
-                       " --window-icon " + get_icon_name(icon) +
+                       " --window-icon " + get_icon_name(_icon) +
                        " --text " + shell_quote(title + "\n" + message);
         }
         else if (is_kdialog())
         {
-            command += " --icon " + get_icon_name(icon) +
+            command += " --icon " + get_icon_name(_icon) +
                        " --title " + shell_quote(title) +
                        " --passivepopup " + shell_quote(message) +
                        " 5";
@@ -1060,12 +1060,12 @@ class message : public internal::dialog
 public:
     message(std::string const &title,
             std::string const &text,
-            choice choice = choice::ok_cancel,
-            icon icon = icon::info)
+            choice _choice = choice::ok_cancel,
+            icon _icon = icon::info)
     {
 #if _WIN32
         UINT style = MB_TOPMOST;
-        switch (icon)
+        switch (_icon)
         {
             case icon::warning: style |= MB_ICONWARNING; break;
             case icon::error: style |= MB_ICONERROR; break;
@@ -1073,7 +1073,7 @@ public:
             /* case icon::info: */ default: style |= MB_ICONINFORMATION; break;
         }
 
-        switch (choice)
+        switch (_choice)
         {
             case choice::ok_cancel: style |= MB_OKCANCEL; break;
             case choice::yes_no: style |= MB_YESNO; break;
@@ -1102,7 +1102,7 @@ public:
         });
 #elif __EMSCRIPTEN__
         std::string full_message;
-        switch (icon)
+        switch (_icon)
         {
             case icon::warning: full_message = "⚠️"; break;
             case icon::error: full_message = "⛔"; break;
@@ -1120,7 +1120,7 @@ public:
                 return window.confirm(UTF8ToString($0)) ? 0 : -1;
             alert(UTF8ToString($0));
             return 0;
-        }, full_message.c_str(), choice == choice::ok_cancel));
+        }, full_message.c_str(), _choice == choice::ok_cancel));
 #else
         auto command = desktop_helper();
 
@@ -1128,7 +1128,7 @@ public:
         {
             command += " -e 'display dialog " + osascript_quote(text) +
                        "     with title " + osascript_quote(title);
-            switch (choice)
+            switch (_choice)
             {
                 case choice::ok_cancel:
                     command += "buttons {\"OK\", \"Cancel\"} "
@@ -1168,7 +1168,7 @@ public:
                     break;
             }
             command += " with icon ";
-            switch (icon)
+            switch (_icon)
             {
                 #define PFD_OSX_ICON(n) "alias ((path to library folder from system domain) as text " \
                     "& \"CoreServices:CoreTypes.bundle:Contents:Resources:" n ".icns\")"
@@ -1182,7 +1182,7 @@ public:
         }
         else if (is_zenity())
         {
-            switch (choice)
+            switch (_choice)
             {
                 case choice::ok_cancel:
                     command += " --question --ok-label=OK --cancel-label=Cancel"; break;
@@ -1197,7 +1197,7 @@ public:
                 case choice::abort_retry_ignore:
                     command += " --question --switch --extra-button Abort --extra-button Retry --extra-button Ignore"; break;
                 default:
-                    switch (icon)
+                    switch (_icon)
                     {
                         case icon::error: command += " --error"; break;
                         case icon::warning: command += " --warning"; break;
@@ -1208,13 +1208,13 @@ public:
             command += " --title " + shell_quote(title)
                      + " --width 300 --height 0" // sensible defaults
                      + " --text " + shell_quote(text)
-                     + " --icon-name=dialog-" + get_icon_name(icon);
+                     + " --icon-name=dialog-" + get_icon_name(_icon);
         }
         else if (is_kdialog())
         {
-            if (choice == choice::ok)
+            if (_choice == choice::ok)
             {
-                switch (icon)
+                switch (_icon)
                 {
                     case icon::error: command += " --error"; break;
                     case icon::warning: command += " --sorry"; break;
@@ -1224,12 +1224,12 @@ public:
             else
             {
                 command += " --";
-                if (icon == icon::warning || icon == icon::error)
+                if (_icon == icon::warning || _icon == icon::error)
                     command += "warning";
                 command += "yesno";
-                if (choice == choice::yes_no_cancel)
+                if (_choice == choice::yes_no_cancel)
                     command += "cancel";
-                if (choice == choice::yes_no || choice == choice::yes_no_cancel)
+                if (_choice == choice::yes_no || _choice == choice::yes_no_cancel)
                 {
                     m_mappings[0] = button::yes;
                     m_mappings[256] = button::no;
@@ -1240,7 +1240,7 @@ public:
                      + " --title " + shell_quote(title);
 
             // Must be after the above part
-            if (choice == choice::ok_cancel)
+            if (_choice == choice::ok_cancel)
                 command += " --yes-label OK --no-label Cancel";
         }
 


### PR DESCRIPTION
Naming argument the same as its type leads to compilation error when using g++ 5.4.0:
`error: choice is not a class, namespace, or enumeration`
It supports C++11 and compiles just fine with fixed argument names.
I checked compilation on windows 10 and linux (ubuntu 16.04).