### PR TITLE
Use StringCchCopyW instead of lstrcpyW on Windows

### DIFF
--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -674,7 +674,8 @@ protected:
                 if (path_attr != INVALID_FILE_ATTRIBUTES && (path_attr & FILE_ATTRIBUTE_DIRECTORY))
                     ofn.lpstrInitialDir = m_wdefault_path.c_str();
                 else if (m_wdefault_path.size() <= woutput.size())
-                    lstrcpyW(ofn.lpstrFile, m_wdefault_path.c_str());
+                    //second argument is size of buffer, not length of string
+                    StringCchCopyW(ofn.lpstrFile, MAX_PATH*256+1, m_wdefault_path.c_str());
                 else
                 {
                     ofn.lpstrFileTitle = (LPWSTR)m_wdefault_path.data();


### PR DESCRIPTION
Use StringCchCopyW instead of lstrcpyW on Windows.

I also was not able to compile using mingw64 when it was using lsctrcpyW. Because it has following define:

```
#undef lstrcpyW
#define lstrcpyW lstrcpyW_instead_use_StringCbCopyW_or_StringCchCopyW;
```

Library already uses StringCchCopyW for notifications on Windows, no reason to not use it here. 