### PR TITLE
Fix trailing slash of pfd::select_folder() on macOS.

### DIFF
--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -1100,7 +1100,7 @@ inline internal::file_dialog::file_dialog(type in_type,
         }
         else
         {
-            script += "\nPOSIX path of ret";
+            script += "\ntext 1 through -2 of POSIX path of ret";
         }
 
         command.push_back("-e");


### PR DESCRIPTION
Using `pfd::select_folder()` on macOS produces a path with a trailing slash, this pr removes the trailing slash so that the result is coherent with the other platforms.