### PR TITLE
Prevent call to back() on empty std::string

### DIFF
--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -1198,13 +1198,10 @@ inline std::string internal::file_dialog::string_result()
     return m_async->result();
 #else
     auto ret = m_async->result();
-    if (!ret.empty())
-    {
-        // Strip potential trailing newline (zenity). Also strip trailing slash
-        // added by osascript for consistency with other backends.
-        while (ret.back() == '\n' || ret.back() == '/')
-            ret = ret.substr(0, ret.size() - 1);
-    }
+    // Strip potential trailing newline (zenity). Also strip trailing slash
+    // added by osascript for consistency with other backends.
+    while (!ret.empty() && (ret.back() == '\n' || ret.back() == '/'))
+        ret = ret.substr(0, ret.size() - 1);
     return ret;
 #endif
 }

--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -1198,10 +1198,13 @@ inline std::string internal::file_dialog::string_result()
     return m_async->result();
 #else
     auto ret = m_async->result();
-    // Strip potential trailing newline (zenity). Also strip trailing slash
-    // added by osascript for consistency with other backends.
-    while (ret.back() == '\n' || ret.back() == '/')
-        ret = ret.substr(0, ret.size() - 1);
+    if (!ret.empty()) {
+        // Strip potential trailing newline (zenity). Also strip trailing slash
+        // added by osascript for consistency with other backends.
+        while (ret.back() == '\n' || ret.back() == '/') {
+            ret = ret.substr(0, ret.size() - 1);
+        }
+    }
     return ret;
 #endif
 }

--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -1198,12 +1198,12 @@ inline std::string internal::file_dialog::string_result()
     return m_async->result();
 #else
     auto ret = m_async->result();
-    if (!ret.empty()) {
+    if (!ret.empty())
+    {
         // Strip potential trailing newline (zenity). Also strip trailing slash
         // added by osascript for consistency with other backends.
-        while (ret.back() == '\n' || ret.back() == '/') {
+        while (ret.back() == '\n' || ret.back() == '/')
             ret = ret.substr(0, ret.size() - 1);
-        }
     }
     return ret;
 #endif


### PR DESCRIPTION
Possible to hit this case if user discards any file selection.