### PR TITLE
Fix build on macOS Sierra

### DIFF
--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -31,6 +31,9 @@
 #ifndef _POSIX_C_SOURCE
 #   define _POSIX_C_SOURCE 2 // for popen()
 #endif
+#ifdef __APPLE__
+#   define _DARWIN_C_SOURCE
+#endif
 #include <cstdio>     // popen()
 #include <cstdlib>    // std::getenv()
 #include <fcntl.h>    // fcntl()


### PR DESCRIPTION
```
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/iostream:38:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/ios:216:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__locale:18:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/mutex:189:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__mutex_base:17:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__threading_support:156:1: error: unknown type name 'mach_port_t'
mach_port_t __libcpp_thread_get_port();
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__threading_support:300:1: error: unknown type name 'mach_port_t'
mach_port_t __libcpp_thread_get_port() {
^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include/c++/v1/__threading_support:301:12: error: use of undeclared identifier 'pthread_mach_thread_np'
    return pthread_mach_thread_np(pthread_self());
           ^
```

A small fix is to add the following to the header (https://github.com/karimnaaji/portable-file-dialogs/blob/master/portable-file-dialogs.h#L34_L36).

To make sure some of these defines don't leak it might be desired to split the implementation in a [stb style](https://github.com/nothings/stb/blob/master/docs/stb_howto.txt). One would have to include portable-file-dialogs with a define wherever implementation is necessary (leaving the interface rather free of system includes):

```
#define PFD_IMPLEMENTATION
#include "portable-file-dialogs.h
```

Mainly to leave the choice to wrap implementation in a cpp file and prevent header leakage. This might be particularly useful for windows.h: this header eventually defines function using common geometry name Polygon/Polyline... in the global namespace, which can conflict with user code. I might eventually do this in my project for this specific issue if I don't find an easy fix (other than wrapping all my code in namespaces), so if you're interested in that I can bring it upstream when done.

 I tested this change on two versions of macOS (Sierra & Catalina) to make sure it still compiles on newer versions.