### PR TITLE
Fixed potential redefinition of macro _DARWIN_C_SOURCE

### DIFF
--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -32,7 +32,9 @@
 #   define _POSIX_C_SOURCE 2 // for popen()
 #endif
 #ifdef __APPLE__
-#   define _DARWIN_C_SOURCE
+#   ifndef _DARWIN_C_SOURCE
+#       define _DARWIN_C_SOURCE
+#   endif
 #endif
 #include <cstdio>     // popen()
 #include <cstdlib>    // std::getenv()


### PR DESCRIPTION
I was getting a compiler warning when including this portable-file-dialogs.h after SDL.h

```
eric@Erics-MacBook-Pro egame-collection2 % cmake --build .   
Scanning dependencies of target egame-collection2
[  5%] Building CXX object CMakeFiles/egame-collection2.dir/src/state/engine_state.cpp.o
In file included from /Users/eric/Projects/egame-collection2/src/state/engine_state.cpp:14:
/Users/eric/Projects/egame-collection2/include/pfd/pfd.h:35:12: warning: '_DARWIN_C_SOURCE' macro redefined [-Wmacro-redefined]
#   define _DARWIN_C_SOURCE
           ^
/usr/local/include/SDL2/SDL2/SDL_stdinc.h:35:9: note: previous definition is here
#define _DARWIN_C_SOURCE 1 /* for memset_pattern4() */
        ^
1 warning generated.
[ 11%] Linking CXX executable egame-collection2
[100%] Built target egame-collection2
```