### PR TITLE
Use lower case filename at #include for MinGW

### DIFF
--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -16,10 +16,10 @@
 #ifndef WIN32_LEAN_AND_MEAN
 #   define WIN32_LEAN_AND_MEAN 1
 #endif
-#include <Windows.h>
+#include <windows.h>
 #include <commdlg.h>
-#include <ShlObj.h>
-#include <ShObjIdl.h> // IFileDialog
+#include <shlobj.h>
+#include <shobjidl.h> // IFileDialog
 #include <shellapi.h>
 #include <strsafe.h>
 #include <future>     // std::async


### PR DESCRIPTION
Windows is case insensitive so "Windows.h" and "windows.h" are both OK, but MinGW on Linux is case sensitive. This PR replaces "Windows.h", "ShlObj.h" and "ShObjIdl.h" with lower case versions. I checked MinGW can compile replaced version.