### PR TITLE
Added virtual dtor for dialog

### DIFF
--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -267,6 +267,7 @@ class dialog : protected settings, protected platform
 public:
     bool ready(int timeout = default_wait_timeout) const;
     bool kill() const;
+    virtual ~dialog() = default;
 
 protected:
     explicit dialog();


### PR DESCRIPTION
Fixes bug detected by gcc's address sanitizer:

```
==261921==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x606000158960 in thread T0:
  object passed to delete has wrong type:
  size of the allocated type:   64 bytes;
  size of the deallocated type: 16 bytes.
    #0 0x7ffad17cb22f in operator delete(void*, unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:172
    #1 0x5639317e2ba9 in std::default_delete<pfd::internal::dialog>::operator()(pfd::internal::dialog*) const /usr/include/c++/11/bits/unique_ptr.h:85
    #2 0x5639319fdc64 in std::unique_ptr<pfd::internal::dialog, std::default_delete<pfd::internal::dialog> >::~unique_ptr() /usr/include/c++/11/bits/unique_ptr.h:361
```