### PR TITLE
Don't use `_dupenv_s` on MinGW.

### DIFF
--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -501,7 +501,7 @@ static inline bool is_directory(std::string const &path)
 
 static inline std::string getenv(std::string const &str)
 {
-#if _WIN32
+#if _MSC_VER
     char *buf = nullptr;
     size_t size = 0;
     if (_dupenv_s(&buf, &size, str.c_str()) == 0 && buf)
@@ -1885,4 +1885,3 @@ inline std::string select_folder::result()
 #endif // PFD_SKIP_IMPLEMENTATION
 
 } // namespace pfd
-


### PR DESCRIPTION
Fixes https://github.com/samhocevar/portable-file-dialogs/issues/80