### PR TITLE
[macOS] Fix save dialog when absolute path is included

### DIFF
--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -1234,11 +1234,20 @@ inline internal::file_dialog::file_dialog(type in_type,
 
         if (default_path.size())
         {
-            if (in_type == type::folder || is_directory(default_path))
-                script += " default location ";
+            if (in_type == type::save && !is_directory(default_path) && default_path.find("/") != std::string::npos)
+            {
+                std::size_t last_slash = default_path.find_last_of("/");
+                script += " default location " + osascript_quote(default_path.substr(0, last_slash));
+                script += " default name " + osascript_quote(default_path.substr(last_slash + 1, default_path.length()));
+            }
             else
-                script += " default name ";
-            script += osascript_quote(default_path);
+            {
+                if (in_type == type::folder || is_directory(default_path))
+                    script += " default location ";
+                else
+                    script += " default name ";
+                script += osascript_quote(default_path);
+            }
         }
 
         script += " with prompt " + osascript_quote(title);


### PR DESCRIPTION
It appears that issue #65 has not been completely fixed - while the dialog displays now, it exhibits the problem talked about by @EvanBalster when providing a complete absolute path: "default name causes the path to be interpreted as a filename rather than a location."

This PR fixes the issue by setting **both** `default name` and `default location` in AppleScript if both are provided in the default path to `pfd::save_file()`. Otherwise, it falls back to the previous logic.

**Before Fix**
![Screen Shot 2023-09-27 at 3 27 48 PM](https://github.com/samhocevar/portable-file-dialogs/assets/24253715/f3130dfe-5fca-4803-ae38-616e6ceeeb7a)

**After Fix**
![Screen Shot 2023-09-27 at 3 32 52 PM](https://github.com/samhocevar/portable-file-dialogs/assets/24253715/c77d436a-a36e-41ce-8ff9-d06bfc1b0632)

