### PR TITLE
Static Lib Building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.1.0)
-
 project(portable_file_dialogs VERSION 1.00 LANGUAGES CXX)
 
 SET(PFD_STATIC_LIB OFF CACHE BOOL "Build portable-file-dialogs as a static library")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,5 +2,12 @@ cmake_minimum_required(VERSION 3.1.0)
 
 project(portable_file_dialogs VERSION 1.00 LANGUAGES CXX)
 
-add_library(${PROJECT_NAME} INTERFACE)
-target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+SET(PFD_STATIC_LIB OFF CACHE BOOL "Build portable-file-dialogs as a static library")
+
+if(PFD_STATIC_LIB)
+    set(PFD_SRC portable-file-dialogs.cpp)
+    add_library(portable-file-dialogs ${PFD_SRC})
+else()
+    add_library(${PROJECT_NAME} INTERFACE)
+    target_include_directories(${PROJECT_NAME} INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+endif()

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A free C++11 file dialog library.
 
 -   works on Windows, Mac OS X, Linux
--   **single-header**, no extra library dependencies
+-   **single-header**, no extra library dependencies (can also be built as a static library if needed)
 -   **synchronous *or* asynchronous** (does not block the rest of your program!)
 -   **cancelable** (kill asynchronous dialogues without user interaction)
 -   **secure** (immune to shell-quote vulnerabilities)

--- a/doc/pfd.md
+++ b/doc/pfd.md
@@ -118,3 +118,17 @@ This is probably only useful for debugging purposes.
 
 Calling `pfd::settings::verbose(true)` may help debug the library. It will output debug information
 to `std::cout` about some operations being performed.
+
+### Building as a static library using CMake
+
+```cpp
+set(PFD_DIR "path_to_portable_file_dialogs")
+set(PFD_STATIC_LIB ON CACHE BOOL "" FORCE)
+add_subdirectory(${PFD_DIR} SYSTEM)
+
+include_directories(SYSTEM path_to_portable_file_dialogs)
+target_link_libraries(Project PUBLIC portable-file-dialogs)
+target_compile_definitions(Project PRIVATE PFD_STATIC)
+```
+
+In static library mode you only need to include the header without any extra defines and the added bonus of less OS bloat in your project

--- a/portable-file-dialogs.cpp
+++ b/portable-file-dialogs.cpp
@@ -1,0 +1,2 @@
+#define PFD_STATIC_BUILD
+#include "portable-file-dialogs.h"

--- a/portable-file-dialogs.h
+++ b/portable-file-dialogs.h
@@ -12,7 +12,7 @@
 
 #pragma once
 
-#ifdef PFD_STATIC_BUILD or defined(PFD_STATIC)
+#if defined(PFD_STATIC_BUILD) || defined(PFD_STATIC)
 #   define PFD_INLINE
 #else
 #   define PFD_INLINE inline


### PR DESCRIPTION
Hi, 

Just added a way of building the library as a static lib, in my specific use case, I was using NOGDI under Windows, which causes the library to not compile. The reason I didn't just removed the define is that it causes some of my apps enums to be invalid (eg: OPAQUE, TRANSPARENT - which are defined in wingdi.h) and also I prefer to keep the OS bloat to the absolute minimum in the main project and this change achieved both of my goals.

Might defeat the purpose of the library and not taken into consideration, but it still keeps the ability of using it as a single header lib, its just an added bonus way of using it.

Cheers,
Alvaro