### PR TITLE
Add compatibility for cmake > 3.5 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.1.0...4.0.0)
 
 project(portable_file_dialogs VERSION 1.00 LANGUAGES CXX)
 


### PR DESCRIPTION
New versions of cmake remove compatibility with older cmake versions. To keep compatibility with older and newer versions we should add a [max policy version](https://cmake.org/cmake/help/latest/command/cmake_minimum_required.html#command:cmake_minimum_required).

This project is still compatible with cmake version 4.0.